### PR TITLE
fix: DIET·EXERCISE 게시글 작성 권한 로직 수정 (B1)

### DIFF
--- a/src/main/java/com/aenggukland/letspt/board/BoardCategory.java
+++ b/src/main/java/com/aenggukland/letspt/board/BoardCategory.java
@@ -1,7 +1,7 @@
 package com.aenggukland.letspt.board;
 
 // 게시글 카테고리 Enum
-// LESSON: 트레이너가 특정 회원에게 작성 / DIET·EXERCISE: 회원 본인이 작성
+// LESSON: 트레이너(TRAINER·MASTER)가 특정 회원에게 작성 / DIET·EXERCISE: 모든 역할이 작성 가능
 public enum BoardCategory {
     LESSON,
     DIET,

--- a/src/main/java/com/aenggukland/letspt/board/BoardController.java
+++ b/src/main/java/com/aenggukland/letspt/board/BoardController.java
@@ -22,7 +22,7 @@ public class BoardController {
     }
 
     // 게시글 생성: 카테고리별 작성 권한을 검증한 후 저장한다
-    // LESSON은 TRAINER·MASTER만, DIET·EXERCISE는 MEMBER만 작성 가능하다
+    // LESSON은 TRAINER·MASTER만, DIET·EXERCISE는 모든 역할이 작성 가능하다
     @PostMapping
     public ResponseEntity<Void> create(@RequestAttribute("username") String username,
                                        @RequestBody @Valid BoardCreateRequest request) {

--- a/src/main/java/com/aenggukland/letspt/board/BoardService.java
+++ b/src/main/java/com/aenggukland/letspt/board/BoardService.java
@@ -124,16 +124,13 @@ public class BoardService {
     }
 
     // 카테고리별 작성 권한 검증
-    // LESSON: TRAINER·MASTER만 작성 가능 / DIET·EXERCISE: MEMBER만 작성 가능 (TODO B1)
+    // LESSON: TRAINER·MASTER만 작성 가능 / DIET·EXERCISE: 모든 역할 작성 가능
     private void validateWritePermission(BoardCategory category, MemberRole role) {
         if (category == BoardCategory.LESSON) {
             if (role != MemberRole.TRAINER && role != MemberRole.MASTER) {
                 throw new BusinessException(ErrorCode.UNAUTHORIZED_BOARD_WRITE);
             }
-        } else {
-            if (role != MemberRole.MEMBER) {
-                throw new BusinessException(ErrorCode.UNAUTHORIZED_BOARD_WRITE);
-            }
         }
+        // DIET·EXERCISE는 MEMBER·TRAINER·MASTER 모두 작성 가능하므로 별도 검증 없음
     }
 }


### PR DESCRIPTION
## Summary

- TRAINER·MASTER가 DIET·EXERCISE 카테고리 게시글을 작성할 수 없던 권한 로직 버그 수정
- `validateWritePermission()`의 잘못된 else 분기 제거
- DIET·EXERCISE는 MEMBER·TRAINER·MASTER 모두 작성 가능하도록 변경

## Test plan

- [ ] TRAINER 계정으로 DIET 게시글 작성 → 성공 확인
- [ ] MASTER 계정으로 EXERCISE 게시글 작성 → 성공 확인
- [ ] MEMBER 계정으로 LESSON 게시글 작성 → 403 확인

Generated with Claude Code