### PR TITLE
fix: BoardCategory.valueOf() 예외 처리 추가 (B2)

### DIFF
--- a/src/main/java/com/aenggukland/letspt/board/BoardCategory.java
+++ b/src/main/java/com/aenggukland/letspt/board/BoardCategory.java
@@ -1,9 +1,22 @@
 package com.aenggukland.letspt.board;
 
+import com.aenggukland.letspt.exception.BusinessException;
+import com.aenggukland.letspt.exception.ErrorCode;
+
 // 게시글 카테고리 Enum
 // LESSON: 트레이너(TRAINER·MASTER)가 특정 회원에게 작성 / DIET·EXERCISE: 모든 역할이 작성 가능
 public enum BoardCategory {
     LESSON,
     DIET,
-    EXERCISE
+    EXERCISE;
+
+    // 문자열로 카테고리를 안전하게 변환한다
+    // valueOf()와 달리 매핑 실패 시 500 대신 400(INVALID_BOARD_CATEGORY)을 반환한다
+    public static BoardCategory from(String value) {
+        try {
+            return BoardCategory.valueOf(value);
+        } catch (IllegalArgumentException e) {
+            throw new BusinessException(ErrorCode.INVALID_BOARD_CATEGORY);
+        }
+    }
 }

--- a/src/main/java/com/aenggukland/letspt/board/BoardService.java
+++ b/src/main/java/com/aenggukland/letspt/board/BoardService.java
@@ -68,7 +68,7 @@ public class BoardService {
     // LESSON 카테고리는 대상 회원(memberId)이 필수이며, 존재 여부 검증은 미구현 (TODO B7)
     public void create(String username, BoardCreateRequest request) {
         Member author = getByUsername(username);
-        BoardCategory category = BoardCategory.valueOf(request.getCategory());
+        BoardCategory category = BoardCategory.from(request.getCategory()); // valueOf() 대신 from() 사용 — 잘못된 값 시 400 반환
         MemberRole role = MemberRole.fromRoleId(author.getRoleId());
 
         validateWritePermission(category, role);

--- a/src/main/java/com/aenggukland/letspt/exception/ErrorCode.java
+++ b/src/main/java/com/aenggukland/letspt/exception/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
     BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "게시글을 찾을 수 없습니다."),
     BOARD_ACCESS_DENIED(HttpStatus.FORBIDDEN, "게시글에 대한 권한이 없습니다."),
     UNAUTHORIZED_BOARD_WRITE(HttpStatus.FORBIDDEN, "해당 카테고리에 글을 작성할 권한이 없습니다."),
+    INVALID_BOARD_CATEGORY(HttpStatus.BAD_REQUEST, "유효하지 않은 게시글 카테고리입니다."),
 
     // Rate Limit
     RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "요청이 너무 많습니다. 잠시 후 다시 시도해주세요."),


### PR DESCRIPTION
## Summary

- `BoardCategory.from()` 정적 팩토리 메서드 추가
- 잘못된 카테고리 입력 시 `IllegalArgumentException`(500) → `BusinessException(INVALID_BOARD_CATEGORY)`(400)으로 변환
- `BoardService`에서 `valueOf()` → `from()`으로 교체

## Test plan

- [ ] 존재하지 않는 카테고리(예: `"INVALID"`)로 게시글 생성 요청 → 400 응답 확인
- [ ] 정상 카테고리(`LESSON`, `DIET`, `EXERCISE`)로 요청 → 정상 동작 확인

Generated with Claude Code