### PR TITLE
fix: 비밀번호 변경 시 기존 Refresh Token 삭제 처리

### DIFF
--- a/src/main/java/com/aenggukland/letspt/member/MemberService.java
+++ b/src/main/java/com/aenggukland/letspt/member/MemberService.java
@@ -133,6 +133,7 @@ public class MemberService {
     }
 
     // 비밀번호 변경: 현재 비밀번호 일치 확인 → 새 비밀번호 동일 여부 확인 → 암호화 후 저장
+    // 변경 성공 시 기존 Refresh Token을 모두 삭제해 탈취된 토큰으로 재발급되는 것을 방지한다
     public void changePassword(String username, PasswordChangeRequest request) {
         Member member = memberMapper.findByUsername(username)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
@@ -145,6 +146,7 @@ public class MemberService {
         }
 
         memberMapper.updatePassword(username, passwordEncoder.encode(request.getNewPassword()));
+        refreshTokenMapper.deleteByUsername(username);
     }
 
     // 프로필 이미지 업로드: MIME 타입 검증 후 UUID 파일명으로 서버에 저장하고 URL을 DB에 기록한다

--- a/src/main/resources/templates/member/my-page-edit.html
+++ b/src/main/resources/templates/member/my-page-edit.html
@@ -304,9 +304,10 @@
         });
 
         if (res.ok) {
-            showToast('비밀번호가 변경되었습니다.');
-            document.getElementById('currentPassword').value = '';
-            document.getElementById('newPassword').value = '';
+            alert('비밀번호가 변경되었습니다. 다시 로그인해주세요.');
+            localStorage.removeItem('accessToken');
+            localStorage.removeItem('refreshToken');
+            location.href = '/login';
         } else {
             const data = await res.json().catch(() => ({}));
             showToast(data.message ?? '변경 실패', true);


### PR DESCRIPTION
비밀번호 변경 성공 시 refreshTokenMapper.deleteByUsername()을 호출해 탈취된 Refresh Token으로 Access Token이 재발급되는 취약점을 차단한다. 프론트에서도 localStorage 토큰을 제거하고 로그인 페이지로 리다이렉트한다.

---
name: PR 템플릿
about: PR 생성 시 이 템플릿을 사용해 주세요!
title: "[PR] "
---

## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요. 예: #이슈번호

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

## 💻 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요. 예: 모든 테스트 통과 여부, 새로 작성한 테스트 케이스 등

## ✅ 변경 사항 체크리스트

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 코드 컨벤션에 따라 코드를 작성했나요?
- [ ] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## 📸 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> 예시: 이 부분의 코드가 잘 작동하는지 테스트해 주실 수 있나요?

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요