### PR TITLE
feat: Refresh Token Rotation 및 재사용 공격 감지 구현

### DIFF
--- a/src/main/java/com/aenggukland/letspt/member/AuthController.java
+++ b/src/main/java/com/aenggukland/letspt/member/AuthController.java
@@ -67,16 +67,16 @@ public class AuthController {
         return ResponseEntity.ok(tokens);
     }
 
-    @Operation(summary = "토큰 재발급", description = "유효한 refreshToken으로 새 accessToken을 발급합니다. Body: {\"refreshToken\": \"...\"}")
+    @Operation(summary = "토큰 재발급", description = "유효한 refreshToken으로 새 accessToken과 refreshToken을 발급합니다. (Rotation) Body: {\"refreshToken\": \"...\"}")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "토큰 재발급 성공"),
+            @ApiResponse(responseCode = "200", description = "토큰 재발급 성공 — accessToken, refreshToken 모두 갱신"),
             @ApiResponse(responseCode = "401", description = "refreshToken 만료 또는 유효하지 않음")
     })
     @SecurityRequirements
     @PostMapping("/refresh")
     public ResponseEntity<Map<String, String>> refresh(@RequestBody Map<String, String> body) {
-        String newAccessToken = memberService.refresh(body.get("refreshToken"));
-        return ResponseEntity.ok(Map.of("accessToken", newAccessToken));
+        Map<String, String> tokens = memberService.refresh(body.get("refreshToken"));
+        return ResponseEntity.ok(tokens);
     }
 
     @Operation(summary = "로그아웃", description = "refreshToken을 무효화하고 accessToken을 블랙리스트에 등록합니다. Body: {\"refreshToken\": \"...\"}")

--- a/src/main/java/com/aenggukland/letspt/member/MemberService.java
+++ b/src/main/java/com/aenggukland/letspt/member/MemberService.java
@@ -22,6 +22,7 @@ import java.nio.file.StandardCopyOption;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -85,14 +86,25 @@ public class MemberService {
         return Map.of("accessToken", accessToken, "refreshToken", refreshToken);
     }
 
-    // Access Token 재발급: Refresh Token 유효성(존재 여부, 만료 여부)을 검증하고 새 토큰을 반환한다
-    // 만료된 경우 DB에서 토큰을 삭제한 뒤 예외를 던진다
-    public String refresh(String refreshToken) {
-        RefreshToken rt = refreshTokenMapper.findByToken(refreshToken)
-                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_TOKEN));
+    // Access Token 재발급 + Refresh Token Rotation
+    // 재발급마다 새 Refresh Token을 발급하고 기존 토큰을 교체한다
+    // 교체된 토큰이 재사용되면 탈취로 간주해 해당 계정의 모든 토큰을 강제 삭제한다
+    public Map<String, String> refresh(String oldRefreshToken) {
+        Optional<RefreshToken> rtOpt = refreshTokenMapper.findByToken(oldRefreshToken);
+
+        if (rtOpt.isEmpty()) {
+            // 이미 교체된 토큰 재사용 → 탈취 가능성 → 강제 전체 로그아웃
+            String username = redisTemplate.opsForValue().get("rotated:" + oldRefreshToken);
+            if (username != null) {
+                refreshTokenMapper.deleteByUsername(username);
+            }
+            throw new BusinessException(ErrorCode.INVALID_TOKEN);
+        }
+
+        RefreshToken rt = rtOpt.get();
 
         if (rt.getExpiresAt().isBefore(LocalDateTime.now())) {
-            refreshTokenMapper.deleteByUsername(rt.getUsername()); // 만료된 토큰 즉시 삭제
+            refreshTokenMapper.deleteByUsername(rt.getUsername());
             throw new BusinessException(ErrorCode.EXPIRED_TOKEN);
         }
 
@@ -100,7 +112,20 @@ public class MemberService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
 
         String roleName = MemberRole.fromRoleId(member.getRoleId()).name();
-        return jwtProvider.createToken(rt.getUsername(), roleName);
+        String newAccessToken = jwtProvider.createToken(rt.getUsername(), roleName);
+        String newRefreshToken = UUID.randomUUID().toString();
+
+        // 기존 토큰을 Redis에 1시간 보관 — 네트워크 오류로 클라이언트가 응답을 못 받은 경우의 grace period
+        redisTemplate.opsForValue().set("rotated:" + oldRefreshToken, rt.getUsername(), 1, TimeUnit.HOURS);
+
+        // DB Refresh Token 교체 (ON CONFLICT (username) DO UPDATE)
+        refreshTokenMapper.save(RefreshToken.builder()
+                .username(rt.getUsername())
+                .token(newRefreshToken)
+                .expiresAt(LocalDateTime.now().plusSeconds(refreshExpirationMs / 1000))
+                .build());
+
+        return Map.of("accessToken", newAccessToken, "refreshToken", newRefreshToken);
     }
 
     // 로그아웃: DB에서 Refresh Token을 삭제해 재사용을 방지한다

--- a/src/test/java/com/aenggukland/letspt/member/MemberServiceTest.java
+++ b/src/test/java/com/aenggukland/letspt/member/MemberServiceTest.java
@@ -20,6 +20,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -152,7 +153,7 @@ class MemberServiceTest {
     // =====================
 
     @Test
-    @DisplayName("유효한 Refresh Token으로 Access Token 재발급 성공")
+    @DisplayName("유효한 Refresh Token으로 Access Token + Refresh Token 재발급 성공 (Rotation)")
     void refreshSuccess() {
         Member member = Member.builder()
                 .username("testuser")
@@ -165,24 +166,50 @@ class MemberServiceTest {
                 .expiresAt(LocalDateTime.now().plusDays(7))
                 .build();
 
+        ValueOperations<String, String> valueOps = mock(ValueOperations.class);
+        when(redisTemplate.opsForValue()).thenReturn(valueOps);
         when(refreshTokenMapper.findByToken("valid-refresh-token")).thenReturn(Optional.of(rt));
         when(memberMapper.findByUsername("testuser")).thenReturn(Optional.of(member));
 
-        String newAccessToken = memberService.refresh("valid-refresh-token");
+        Map<String, String> tokens = memberService.refresh("valid-refresh-token");
 
-        assertThat(newAccessToken).isNotBlank();
-        assertThat(jwtProvider.validateToken(newAccessToken)).isTrue();
+        assertThat(tokens).containsKeys("accessToken", "refreshToken");
+        assertThat(jwtProvider.validateToken(tokens.get("accessToken"))).isTrue();
+        assertThat(tokens.get("refreshToken")).isNotBlank();
+        assertThat(tokens.get("refreshToken")).isNotEqualTo("valid-refresh-token");
+
+        verify(valueOps).set(eq("rotated:valid-refresh-token"), eq("testuser"), eq(1L), eq(TimeUnit.HOURS));
+        verify(refreshTokenMapper).save(any(RefreshToken.class));
     }
 
     @Test
     @DisplayName("존재하지 않는 Refresh Token으로 재발급 시 예외 발생")
     void refreshInvalidToken() {
+        ValueOperations<String, String> valueOps = mock(ValueOperations.class);
+        when(redisTemplate.opsForValue()).thenReturn(valueOps);
         when(refreshTokenMapper.findByToken("invalid-token")).thenReturn(Optional.empty());
+        when(valueOps.get("rotated:invalid-token")).thenReturn(null);
 
         assertThatThrownBy(() -> memberService.refresh("invalid-token"))
                 .isInstanceOf(BusinessException.class)
                 .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                         .isEqualTo(ErrorCode.INVALID_TOKEN));
+    }
+
+    @Test
+    @DisplayName("이미 교체된 Refresh Token 재사용 시 해당 계정 강제 로그아웃")
+    void refreshReuseAttack() {
+        ValueOperations<String, String> valueOps = mock(ValueOperations.class);
+        when(redisTemplate.opsForValue()).thenReturn(valueOps);
+        when(refreshTokenMapper.findByToken("rotated-token")).thenReturn(Optional.empty());
+        when(valueOps.get("rotated:rotated-token")).thenReturn("testuser");
+
+        assertThatThrownBy(() -> memberService.refresh("rotated-token"))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.INVALID_TOKEN));
+
+        verify(refreshTokenMapper).deleteByUsername("testuser");
     }
 
     @Test


### PR DESCRIPTION
재발급 시마다 새 Refresh Token을 발급하고 기존 토큰을 교체한다.
교체된 토큰이 재사용되면 탈취로 간주하여 Redis에서 username을 조회한 뒤
해당 계정의 모든 Refresh Token을 즉시 삭제해 강제 로그아웃 처리한다.

---
name: PR 템플릿
about: PR 생성 시 이 템플릿을 사용해 주세요!
title: "[PR] "
---

## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요. 예: #이슈번호

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

## 💻 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요. 예: 모든 테스트 통과 여부, 새로 작성한 테스트 케이스 등

## ✅ 변경 사항 체크리스트

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 코드 컨벤션에 따라 코드를 작성했나요?
- [ ] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## 📸 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> 예시: 이 부분의 코드가 잘 작동하는지 테스트해 주실 수 있나요?

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요