### PR TITLE
fix: X-Forwarded-For 헤더 스푸핑으로 Rate Limit 우회 가능한 취약점 수정

### DIFF
--- a/src/main/java/com/aenggukland/letspt/security/RateLimitFilter.java
+++ b/src/main/java/com/aenggukland/letspt/security/RateLimitFilter.java
@@ -3,19 +3,25 @@ package com.aenggukland.letspt.security;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.bucket4j.Bandwidth;
 import io.github.bucket4j.Bucket;
+import jakarta.annotation.PostConstruct;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.security.web.util.matcher.IpAddressMatcher;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 // IP 기반 Rate Limiting 필터: 브루트포스·대량 가입 공격을 방어한다
 // 인증 관련 엔드포인트에만 적용되며, JwtFilter보다 앞에서 실행된다
@@ -23,12 +29,28 @@ import java.util.concurrent.ConcurrentHashMap;
 @Component
 public class RateLimitFilter extends OncePerRequestFilter {
 
+    // X-Forwarded-For를 신뢰할 프록시 IP/CIDR 목록 (쉼표 구분)
+    // 신뢰 목록 외 remoteAddr에서 온 요청은 헤더를 무시해 스푸핑을 차단한다
+    @Value("${app.security.trusted-proxies:127.0.0.1,::1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16}")
+    private String trustedProxiesConfig;
+
+    private List<IpAddressMatcher> trustedProxyMatchers;
+
     // 경로별 IP → Bucket 매핑 (ConcurrentHashMap으로 스레드 안전 보장)
     private final ConcurrentHashMap<String, Bucket> loginBuckets = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, Bucket> registerBuckets = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, Bucket> refreshBuckets = new ConcurrentHashMap<>();
 
     private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @PostConstruct
+    private void initTrustedProxyMatchers() {
+        trustedProxyMatchers = Arrays.stream(trustedProxiesConfig.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .map(IpAddressMatcher::new)
+                .collect(Collectors.toList());
+    }
 
     // 요청 경로와 IP를 확인해 해당 버킷에서 토큰을 소비한다
     // 토큰 소비 실패 시 429 응답을 반환하고 필터 체인을 중단한다
@@ -96,14 +118,21 @@ public class RateLimitFilter extends OncePerRequestFilter {
         return null;
     }
 
-    // 클라이언트 IP 추출: 프록시 환경에서는 X-Forwarded-For 헤더를 우선 사용한다
+    // 클라이언트 IP 추출: 신뢰된 프록시에서 온 요청에만 X-Forwarded-For를 사용한다
+    // 신뢰 목록 외 출처의 헤더는 무시해 IP 스푸핑으로 Rate Limit 우회하는 것을 차단한다
     private String extractIp(HttpServletRequest request) {
-        String forwarded = request.getHeader("X-Forwarded-For");
-        if (forwarded != null && !forwarded.isBlank()) {
-            // X-Forwarded-For는 "실제IP, 프록시IP, ..." 형태이므로 첫 번째 값이 원본 IP
-            return forwarded.split(",")[0].trim();
+        String remoteAddr = request.getRemoteAddr();
+        if (isTrustedProxy(remoteAddr)) {
+            String forwarded = request.getHeader("X-Forwarded-For");
+            if (forwarded != null && !forwarded.isBlank()) {
+                // X-Forwarded-For는 "실제IP, 프록시IP, ..." 형태이므로 첫 번째 값이 원본 IP
+                return forwarded.split(",")[0].trim();
+            }
         }
-        // 프록시 없으면 그냥 직접 연결 IP
-        return request.getRemoteAddr();
+        return remoteAddr;
+    }
+
+    private boolean isTrustedProxy(String ip) {
+        return trustedProxyMatchers.stream().anyMatch(matcher -> matcher.matches(ip));
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -61,3 +61,7 @@ firebase:
 
 cors:
   allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000}
+
+app:
+  security:
+    trusted-proxies: ${TRUSTED_PROXIES:127.0.0.1,::1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16}


### PR DESCRIPTION
신뢰된 프록시(사설 IP 대역)에서 온 요청에만 X-Forwarded-For를 사용하고,
외부에서 직접 전달된 헤더는 무시해 IP 위조로 Rate Limit을 우회하는 공격을 차단한다. 신뢰 프록시 목록은 TRUSTED_PROXIES 환경변수로 관리하며 기본값으로 AWS VPC 사설 대역을 포함한다.

---
name: PR 템플릿
about: PR 생성 시 이 템플릿을 사용해 주세요!
title: "[PR] "
---

## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요. 예: #이슈번호

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

## 💻 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요. 예: 모든 테스트 통과 여부, 새로 작성한 테스트 케이스 등

## ✅ 변경 사항 체크리스트

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 코드 컨벤션에 따라 코드를 작성했나요?
- [ ] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## 📸 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> 예시: 이 부분의 코드가 잘 작동하는지 테스트해 주실 수 있나요?

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요