### PR TITLE
fix: Rate Limit을 Redis 기반 분산 카운터로 전환해 다중 인스턴스 환경에서 우회 불가하도록 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,6 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
-    implementation 'com.bucket4j:bucket4j-core:8.10.1'
     //WebSocket
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     //Kafka

--- a/src/main/java/com/aenggukland/letspt/security/RateLimitFilter.java
+++ b/src/main/java/com/aenggukland/letspt/security/RateLimitFilter.java
@@ -1,14 +1,14 @@
 package com.aenggukland.letspt.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.github.bucket4j.Bandwidth;
-import io.github.bucket4j.Bucket;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.web.util.matcher.IpAddressMatcher;
@@ -16,16 +16,15 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 // IP 기반 Rate Limiting 필터: 브루트포스·대량 가입 공격을 방어한다
 // 인증 관련 엔드포인트에만 적용되며, JwtFilter보다 앞에서 실행된다
 // 제한: login 10회/분, register 5회/분, refresh 30회/분 (IP당)
+// Redis Lua 스크립트로 INCR+EXPIRE를 원자적으로 실행해 다중 인스턴스 환경에서도 정확한 카운팅 보장
 @Component
 public class RateLimitFilter extends OncePerRequestFilter {
 
@@ -36,12 +35,30 @@ public class RateLimitFilter extends OncePerRequestFilter {
 
     private List<IpAddressMatcher> trustedProxyMatchers;
 
-    // 경로별 IP → Bucket 매핑 (ConcurrentHashMap으로 스레드 안전 보장)
-    private final ConcurrentHashMap<String, Bucket> loginBuckets = new ConcurrentHashMap<>();
-    private final ConcurrentHashMap<String, Bucket> registerBuckets = new ConcurrentHashMap<>();
-    private final ConcurrentHashMap<String, Bucket> refreshBuckets = new ConcurrentHashMap<>();
-
+    private final StringRedisTemplate redisTemplate;
     private final ObjectMapper objectMapper = new ObjectMapper();
+
+    // 고정 윈도우(fixed-window) Lua 스크립트:
+    // INCR로 카운트 증가 후, 첫 요청일 때만 EXPIRE 설정해 윈도우를 시작한다
+    private static final RedisScript<Long> RATE_LIMIT_SCRIPT = RedisScript.of("""
+            local count = redis.call('INCR', KEYS[1])
+            if count == 1 then
+              redis.call('EXPIRE', KEYS[1], ARGV[1])
+            end
+            return count
+            """, Long.class);
+
+    private record RateLimitRule(int limit, int windowSec) {}
+
+    private static final Map<String, RateLimitRule> RULES = Map.of(
+            "/api/auth/login",    new RateLimitRule(10, 60),
+            "/api/auth/register", new RateLimitRule(5,  60),
+            "/api/auth/refresh",  new RateLimitRule(30, 60)
+    );
+
+    public RateLimitFilter(StringRedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
 
     @PostConstruct
     private void initTrustedProxyMatchers() {
@@ -52,25 +69,23 @@ public class RateLimitFilter extends OncePerRequestFilter {
                 .collect(Collectors.toList());
     }
 
-    // 요청 경로와 IP를 확인해 해당 버킷에서 토큰을 소비한다
-    // 토큰 소비 실패 시 429 응답을 반환하고 필터 체인을 중단한다
     @Override
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
 
         String path = request.getRequestURI();
-        String ip = extractIp(request);
+        RateLimitRule rule = RULES.get(path);
 
-        Bucket bucket = resolveBucket(path, ip);
-
-        if (bucket == null) {
-            // 제한 대상 경로가 아니면 그냥 통과
+        if (rule == null) {
             filterChain.doFilter(request, response);
             return;
         }
 
-        if (bucket.tryConsume(1)) {
+        String ip = extractIp(request);
+        String key = "rl:" + path + ":" + ip;
+
+        if (isAllowed(key, rule)) {
             filterChain.doFilter(request, response);
         } else {
             response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
@@ -82,40 +97,19 @@ public class RateLimitFilter extends OncePerRequestFilter {
         }
     }
 
-    // 경로에 따라 알맞은 버킷 맵에서 IP별 버킷을 반환한다
-    // 처음 요청하는 IP라면 새 버킷을 생성해 저장한다
-    private Bucket resolveBucket(String path, String ip) {
-        if (path.equals("/api/auth/login")) {
-            // 로그인: IP당 10회/분
-            return loginBuckets.computeIfAbsent(ip, k ->
-                    Bucket.builder()
-                            .addLimit(Bandwidth.builder()
-                                    .capacity(10)
-                                    .refillGreedy(10, Duration.ofMinutes(1))
-                                    .build())
-                            .build());
+    private boolean isAllowed(String key, RateLimitRule rule) {
+        try {
+            Long count = redisTemplate.execute(
+                    RATE_LIMIT_SCRIPT,
+                    List.of(key),
+                    String.valueOf(rule.windowSec())
+            );
+            return count != null && count <= rule.limit();
+        } catch (Exception e) {
+            // Redis 장애 시 fail-open: 서비스 가용성 우선, 경고 로그만 출력
+            logger.warn("Redis rate limit unavailable, fail-open: " + e.getMessage());
+            return true;
         }
-        if (path.equals("/api/auth/register")) {
-            // 회원가입: IP당 5회/분
-            return registerBuckets.computeIfAbsent(ip, k ->
-                    Bucket.builder()
-                            .addLimit(Bandwidth.builder()
-                                    .capacity(5)
-                                    .refillGreedy(5, Duration.ofMinutes(1))
-                                    .build())
-                            .build());
-        }
-        if (path.equals("/api/auth/refresh")) {
-            // 토큰 재발급: IP당 30회/분
-            return refreshBuckets.computeIfAbsent(ip, k ->
-                    Bucket.builder()
-                            .addLimit(Bandwidth.builder()
-                                    .capacity(30)
-                                    .refillGreedy(30, Duration.ofMinutes(1))
-                                    .build())
-                            .build());
-        }
-        return null;
     }
 
     // 클라이언트 IP 추출: 신뢰된 프록시에서 온 요청에만 X-Forwarded-For를 사용한다


### PR DESCRIPTION
ConcurrentHashMap + Bucket4j 인메모리 버킷은 단일 JVM 한정이라 EC2 다중 인스턴스 배포 시 인스턴스별로 독립 카운팅되어 Rate Limit이 사실상 무력화되는 문제 수정.
Redis Lua 스크립트(INCR + EXPIRE)로 원자적 고정 윈도우 카운터를 구현해 전 인스턴스가 동일한 카운트를 공유하도록 변경. Redis 장애 시 fail-open으로 서비스 가용성 유지. bucket4j-core 의존성 제거.

---
name: PR 템플릿
about: PR 생성 시 이 템플릿을 사용해 주세요!
title: "[PR] "
---

## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요. 예: #이슈번호

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

## 💻 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요. 예: 모든 테스트 통과 여부, 새로 작성한 테스트 케이스 등

## ✅ 변경 사항 체크리스트

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 코드 컨벤션에 따라 코드를 작성했나요?
- [ ] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## 📸 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> 예시: 이 부분의 코드가 잘 작동하는지 테스트해 주실 수 있나요?

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요