### PR TITLE
feat: 당일 수업 알림 스케줄러 구현

### DIFF
--- a/src/main/java/com/aenggukland/letspt/fcm/FcmType.java
+++ b/src/main/java/com/aenggukland/letspt/fcm/FcmType.java
@@ -5,7 +5,8 @@ public enum FcmType {
     SCHEDULE_REQUEST("일정 요청"),
     SCHEDULE_CONFIRM("일정 확인"),
     SCHEDULE_CANCEL("트레이너의 일정 취소"),
-    SCHEDULE_MEMBER_CANCEL("회원의 일정 취소");
+    SCHEDULE_MEMBER_CANCEL("회원의 일정 취소"),
+    SCHEDULE_TODAY_REMINDER("오늘 수업 알림");
 
     private final String title;
 

--- a/src/main/java/com/aenggukland/letspt/schedule/ScheduleMapper.java
+++ b/src/main/java/com/aenggukland/letspt/schedule/ScheduleMapper.java
@@ -25,4 +25,6 @@ public interface ScheduleMapper {
     List<ScheduleResponse> getMemberSchedule(Long memberId);
 
     List<ScheduleResponse> getTrainerSchedule(Long memberId);
+
+    List<TodayScheduleResult> getTodaySchedules();
 }

--- a/src/main/java/com/aenggukland/letspt/schedule/TodayScheduleResult.java
+++ b/src/main/java/com/aenggukland/letspt/schedule/TodayScheduleResult.java
@@ -1,0 +1,20 @@
+package com.aenggukland.letspt.schedule;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TodayScheduleResult {
+    private Long scheduleId;
+    private Long trainerId;
+    private Long memberId;
+    private LocalDateTime startDateTime;
+    private String classContent;
+    private String trainerName;
+    private String memberName;
+}

--- a/src/main/java/com/aenggukland/letspt/scheduler/Scheduler.java
+++ b/src/main/java/com/aenggukland/letspt/scheduler/Scheduler.java
@@ -1,10 +1,16 @@
 package com.aenggukland.letspt.scheduler;
 
+import com.aenggukland.letspt.common.CommonMethod;
 import com.aenggukland.letspt.fcm.FcmTokenMapper;
-import lombok.AllArgsConstructor;
+import com.aenggukland.letspt.fcm.FcmTokenService;
+import com.aenggukland.letspt.fcm.FcmType;
+import com.aenggukland.letspt.schedule.ScheduleMapper;
+import com.aenggukland.letspt.schedule.TodayScheduleResult;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 // 주기적으로 실행되는 스케줄러
 // @EnableScheduling은 LetSptApplication에 선언되어 있다
@@ -12,11 +18,34 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class Scheduler {
     private final FcmTokenMapper fcmTokenMapper;
+    private final FcmTokenService fcmTokenService;
+    private final ScheduleMapper scheduleMapper;
 
     // FCM 토큰 만료 처리: 매일 자정에 만료된 토큰의 is_expired 플래그를 true로 변경한다
     // 만료 토큰은 sendPush() 조회 시 제외되어 불필요한 FCM 요청을 줄인다
     @Scheduled(cron = "0 0 0 * * *") // 매일 자정
     public void expireFcmTokens() {
         fcmTokenMapper.updateExpiredToken();
+    }
+
+    // 당일 수업 알림: 매일 오전 8시에 오늘 COMPLETE 상태인 수업의 회원·트레이너에게 FCM 푸시를 발송한다
+    @Scheduled(cron = "0 0 8 * * *") // 매일 오전 8시
+    public void notifyTodaySchedules() {
+        List<TodayScheduleResult> todaySchedules = scheduleMapper.getTodaySchedules();
+        for (TodayScheduleResult schedule : todaySchedules) {
+            String startTime = CommonMethod.formatDateTime(schedule.getStartDateTime());
+            fcmTokenService.sendPush(
+                    schedule.getMemberId(),
+                    FcmType.SCHEDULE_TODAY_REMINDER,
+                    schedule.getTrainerName() + "님과 " + startTime + "에 " + schedule.getClassContent() + " 수업이 있습니다.",
+                    schedule.getScheduleId()
+            );
+            fcmTokenService.sendPush(
+                    schedule.getTrainerId(),
+                    FcmType.SCHEDULE_TODAY_REMINDER,
+                    schedule.getMemberName() + "님과 " + startTime + "에 " + schedule.getClassContent() + " 수업이 있습니다.",
+                    schedule.getScheduleId()
+            );
+        }
     }
 }

--- a/src/main/resources/mapper/ScheduleMapper.xml
+++ b/src/main/resources/mapper/ScheduleMapper.xml
@@ -76,4 +76,20 @@
         WHERE schedule_id = #{scheduleId}
     </update>
 
+    <!-- 당일 수업 알림: 오늘 날짜에 COMPLETE 상태인 수업과 트레이너·회원 이름을 함께 조회 -->
+    <select id="getTodaySchedules" resultType="com.aenggukland.letspt.schedule.TodayScheduleResult">
+        SELECT s.schedule_id,
+               s.trainer_id,
+               s.member_id,
+               s.start_datetime,
+               s.class_content,
+               t.name AS trainer_name,
+               m.name AS member_name
+        FROM schedule s
+                 INNER JOIN member t ON s.trainer_id = t.member_id
+                 INNER JOIN member m ON s.member_id  = m.member_id
+        WHERE s.state = 'COMPLETE'
+          AND DATE(s.start_datetime) = CURRENT_DATE
+    </select>
+
 </mapper>


### PR DESCRIPTION
매일 오전 8시에 당일 COMPLETE 상태 수업의 회원·트레이너 양측에 FCM 푸시 알림을 발송한다. TodayScheduleResult DTO 추가, ScheduleMapper에 당일 수업 조회 쿼리 추가, FcmType에 SCHEDULE_TODAY_REMINDER 추가.

---
name: PR 템플릿
about: PR 생성 시 이 템플릿을 사용해 주세요!
title: "[PR] "
---

## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요. 예: #이슈번호

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

## 💻 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요. 예: 모든 테스트 통과 여부, 새로 작성한 테스트 케이스 등

## ✅ 변경 사항 체크리스트

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 코드 컨벤션에 따라 코드를 작성했나요?
- [ ] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## 📸 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> 예시: 이 부분의 코드가 잘 작동하는지 테스트해 주실 수 있나요?

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요